### PR TITLE
station页面样式

### DIFF
--- a/src/common/stylus/base.styl
+++ b/src/common/stylus/base.styl
@@ -32,6 +32,7 @@ li
 	width: 100%
 	background-color: #fff
 	z-index: 666
+	box-shadow: 0 3px 20px rgba(0, 0, 0, 0.1)
 
 .btn-bar
 	align-self: center
@@ -48,7 +49,7 @@ li
 		color: #AFAFAF
 		
 .info
-	margin-top: 193.3px
+	// margin-top: 186.7px
 	z-index: -1
 	
 .settings
@@ -138,4 +139,7 @@ h3
 .custom-cursor-pointer
 
 	cursor:pointer
+	
+.middleline-topbar
+	margin-top: 173.3px
 

--- a/src/components/addCaller/addCaller.vue
+++ b/src/components/addCaller/addCaller.vue
@@ -26,8 +26,9 @@
 				     	<div class="item btn btn-warning" @click="cancel">取消</div>
 					</div>
 				</div>
-				<middleLine height='13.4'></middleLine>
+				
 			</div>
+			<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	     	<div class="container info">
 		     	<div class="row baseinfo">
 		     		<h3>基础信息</h3>

--- a/src/components/addQueue/addQueue.vue
+++ b/src/components/addQueue/addQueue.vue
@@ -10,8 +10,8 @@
 	     			<div class="item btn btn-warning" @click="cancel">取消</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 		<div class="container info">
 	     	<div class="baseinfo">
 	     		<h3>基础信息</h3>

--- a/src/components/addStation/addStation.vue
+++ b/src/components/addStation/addStation.vue
@@ -10,8 +10,9 @@
 			     	<div class="item btn btn-warning" @click="cancel">取消</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	    <div class="container info">
 	     	<div class="baseinfo">
 	     		<h3>基础信息</h3>

--- a/src/components/addWorker/addWorker.vue
+++ b/src/components/addWorker/addWorker.vue
@@ -16,8 +16,9 @@
 	     			<div class="item btn btn-warning" @click="cancel">取消</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 
 	     <div class="container info">
 

--- a/src/components/batchAddWorker/batchAddWorker.vue
+++ b/src/components/batchAddWorker/batchAddWorker.vue
@@ -10,8 +10,9 @@
 	     			<div class="item btn btn-warning" @click="cancel">取消</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	     <div class="container info">
 	     	<div class="row baseinfo">
 	     		<h3>数据库信息</h3>

--- a/src/components/editCaller/editCaller.vue
+++ b/src/components/editCaller/editCaller.vue
@@ -19,8 +19,9 @@
 				     	<div class="item btn btn-danger" @click="del">取消</div>
 					</div>
 				</div>
-				<middleLine height='13.4'></middleLine>
+				
 			</div>
+			<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	     	<div class="container info">
 		     	<div class="row baseinfo">
 		     	    <h2>编辑叫号器</h2>

--- a/src/components/editQueue/editQueue.vue
+++ b/src/components/editQueue/editQueue.vue
@@ -31,8 +31,9 @@
 	     			<div class="item btn btn-warning" @click="del">删除</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	     <div class="container info">
 	     	<div class="row baseinfo">
 	     		<h3>基础信息</h3>

--- a/src/components/editStation/editStation.vue
+++ b/src/components/editStation/editStation.vue
@@ -11,8 +11,9 @@
 	     			<div class="item btn btn-danger" @click="del">删除</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	    <div class="container info">
 	     	<div class="baseinfo">
 	     		<h3>基础信息</h3>

--- a/src/components/editWorker/editWorker.vue
+++ b/src/components/editWorker/editWorker.vue
@@ -15,8 +15,9 @@
 			     	<div class="item btn btn-danger" @click="del">删除</div>
 				</div>
 			</div>
-			<middleLine height='13.4'></middleLine>
+			
 		</div>
+		<middleLine height='13.4' class="middleline-topbar"></middleLine>
 	     <div class="container info">
 	     	<div class="row baseinfo">
      			<h3>基础信息</h3>

--- a/src/components/station/station.vue
+++ b/src/components/station/station.vue
@@ -81,7 +81,7 @@
  			<div class="top-bar">
  				<div class="container settings">
  					<div class="capital">
- 						<span>{{stationName}}</span>/分诊台详情
+ 						<span>分诊台</span>/{{stationName}}
  					</div>
 	                <div v-if="showInfoNumber == 0" class="btn-bar">
 	 	               	<div class="item btn btn-success" @click="add('addWorker', stationName)">添加医生</div>
@@ -96,15 +96,14 @@
  						<!-- <div class="item btn btn-success" @click="addStation">提交</div>
  				     	<div class="item btn btn-warning" @click="cancel">取消</div> -->
  				</div>
- 				<middleLine height='13.4'></middleLine>
  			</div>
+ 			<middleLine height='13.4' class="middleline-topbar"></middleLine>
             <div class="station-content  container info no-left-padding">
 	               <div class="nav-bar">
-	               	     <div class="station-name ">{{stationName}}</div>
-	               	     <div class="tab-title  text-center" @click="showInfo(0)">医生信息</div>
-	               	     <div class="tab-title text-center" @click="showInfo(1)">队列</div>
-	               	     <div class="tab-title text-center" @click="showInfo(2)">叫号器</div>
-	               	     <div class="tab-title text-center" @click="edit('editStation', {'stationID':stationID}, stationName )">配置分诊台</div>
+	               	     <div class="tab-title  text-center custom-cursor-pointer" @click="showInfo(0)">医生信息</div>
+	               	     <div class="tab-title text-center custom-cursor-pointer" @click="showInfo(1)">队列</div>
+	               	     <div class="tab-title text-center custom-cursor-pointer" @click="showInfo(2)">叫号器</div>
+	               	     <div class="tab-title text-center custom-cursor-pointer" @click="edit('editStation', {'stationID':stationID}, stationName )">配置分诊台</div>
 	               </div>
 	               <div class="nav-info">
 	               	   <div class="workList nav-info-content" v-if="showInfoNumber == 0">

--- a/src/components/station/station.vue
+++ b/src/components/station/station.vue
@@ -74,6 +74,10 @@
 	color: #A5A5A5;
 }
 
+.edit {
+	color: #0097FB;
+}
+
 </style>
 <template lang="html">
     <div>
@@ -126,7 +130,7 @@
 	               	   	   	        	<td>{{worker.ip}}</td>
 	               	   	   	        	<td>{{worker.type}}</td>
 	               	   	   	        	<td>{{worker.title}}</td>
-	               	   	   	        	<td @click="edit('editWorker', worker, stationName)">编辑</td>
+	               	   	   	        	<td class="custom-cursor-pointer edit" @click="edit('editWorker', worker, stationName)">编辑</td>
 	               	   	   	        </tr>	
 	               	   	   	    </tbody>
 	               	   	   </table>

--- a/src/components/stationList/stationList.vue
+++ b/src/components/stationList/stationList.vue
@@ -1,11 +1,9 @@
 <template lang="html">
 	<div class="">
-	       <div class="addstation-container">
-
+	       <div class="top-bar">
 		       	<button class="addstation"  @click="goToState('addStation')"><h3>新建分诊台</h3></button>
-
 	       </div>
-	       <middleLine height='13.4'></middleLine>
+	       <middleLine height='13.4' class="middleline-topbar"></middleLine>
 		   	<div class="card-container">
    				<div v-for="station in stationList" class="card-box" @click="goToStationDetail(station)">
    					<div class="card">
@@ -178,6 +176,7 @@ a, button, input
 		text-align: center
 		margin-top: 0.67em
 		margin-bottom: 1.33em
+		border-bottom: none
 
 .card-bg
 	height: 173.3px
@@ -192,13 +191,6 @@ a, button, input
 	.icon-fenzhentai2:active,.icon-fenzhentai2:hover
 		color: #00C7FF
 
-.addstation-container
-	display: flex
-	align-items: center
-	justify-content: center
-	height: 93.3px
-	margin-top: 80px
-
 .addstation
 	width: 4.73em
 	height: 1.3em
@@ -211,5 +203,12 @@ a, button, input
 	color:#fff
 	font-size: 30px
 	border: none
+
+.top-bar
+	display: flex
+	align-items: center
+	justify-content: center
+	height: 93.3px
+	
 
 </style>


### PR DESCRIPTION
1. stationlist 页面，card的下框线去掉
2. middleline定位：随着页面滚动向上滚动（之前是fixed在页面顶部）
3. station页面“编辑”样式调整

注释：
剩余需求：
1. 左侧“配置分诊台”样式待调整
2. manage四个tag间距待调整